### PR TITLE
Removed the ability to change username under editprofile

### DIFF
--- a/frontend/src/Pages/EditProfile.js
+++ b/frontend/src/Pages/EditProfile.js
@@ -79,10 +79,10 @@ export default function EditProfile() {
                 />
                 <br />
                 <label htmlFor="username">Username </label>
+                {/* Doesn't allow username to be changed but still displays it to the user. */}
                 <input
                     value={username}
                     name="username"
-                    onChange={(e) => setUsername(e.target.value)}
                     id="username"
                 />
                 <br />


### PR DESCRIPTION
Users can not change usernames anymore. This is due to issues that would be caused with the posts if usernames are changed.